### PR TITLE
[265] add test cases for EcoNewsDtoRequestValidator

### DIFF
--- a/core/src/test/java/greencity/validator/EcoNewsDtoRequestValidatorTest.java
+++ b/core/src/test/java/greencity/validator/EcoNewsDtoRequestValidatorTest.java
@@ -1,23 +1,69 @@
 package greencity.validator;
 
 import greencity.dto.econews.AddEcoNewsDtoRequest;
+import greencity.exception.exceptions.InvalidURLException;
+import greencity.exception.exceptions.WrongCountOfTagsException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
 
 import static greencity.ModelUtils.getAddEcoNewsDtoRequest;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@ExtendWith(SpringExtension.class)
+@ExtendWith(MockitoExtension.class)
 class EcoNewsDtoRequestValidatorTest {
     @InjectMocks
     private EcoNewsDtoRequestValidator validator;
 
     @Test
-    void isValidTrueTest() {
+    void isUrlValid_ValidSourceURL_ReturnsTrue() {
         AddEcoNewsDtoRequest request = getAddEcoNewsDtoRequest();
         request.setSource("https://eco-lavca.ua/");
         assertTrue(validator.isValid(request, null));
+    }
+
+    @Test
+    void isUrlValid_InvalidSourceURL_ThrowsInvalidURLException() {
+        AddEcoNewsDtoRequest request = getAddEcoNewsDtoRequest();
+        request.setSource("invalidURL");
+        assertThrows(InvalidURLException.class, () -> validator.isValid(request, null));
+    }
+
+    @Test
+    void isUrlValid_NullSourceURL_ReturnsTrue() {
+        AddEcoNewsDtoRequest request = getAddEcoNewsDtoRequest();
+        assertTrue(validator.isValid(request, null));
+    }
+
+    @Test
+    void isUrlValid_EmptySourceURL_ReturnsTrue() {
+        AddEcoNewsDtoRequest request = getAddEcoNewsDtoRequest();
+        request.setSource("");
+        assertTrue(validator.isValid(request, null));
+    }
+
+    @Test
+    void isTagsValid_ValidAmountOfTags_ReturnsTrue() {
+        AddEcoNewsDtoRequest request = getAddEcoNewsDtoRequest();
+        request.setTags(List.of("tag1"));
+        assertTrue(validator.isValid(request, null));
+    }
+
+    @Test
+    void isTagsValid_InvalidAmountOfTags_ThrowsWrongCountOfTagsException() {
+        AddEcoNewsDtoRequest request = getAddEcoNewsDtoRequest();
+        request.setTags(List.of("tag1", "tag2", "tag3", "tag4"));
+        assertThrows(WrongCountOfTagsException.class, () -> validator.isValid(request, null));
+    }
+
+    @Test
+    void isTagsValid_EmptyTags_ThrowsWrongCountOfTagsException() {
+        AddEcoNewsDtoRequest request = getAddEcoNewsDtoRequest();
+        request.setTags(List.of());
+        assertThrows(WrongCountOfTagsException.class, () -> validator.isValid(request, null));
     }
 }


### PR DESCRIPTION
Added test cases for EcoNewsDtoRequestValidator

The isValid() method is covered by tests 100%, but the initialize() method isn't covered, as it doesn't have any logic and is part of the ConstraintValidator interface in the Jakarta Validation API.
<img width="599" alt="Знімок екрана 2024-05-18 о 14 33 38" src="https://github.com/GreenCityProject/GreenCityMVP21_team1_May/assets/128901331/c5249aaa-8ba9-4eba-b5e7-7a51d9b11093">
