### PR TITLE
[327] Delete notification

### DIFF
--- a/core/src/main/java/greencity/config/SecurityConfig.java
+++ b/core/src/main/java/greencity/config/SecurityConfig.java
@@ -284,6 +284,9 @@ public class SecurityConfig {
                                 "/facts/{factId}",
                                 "/comments")
                         .hasAnyRole(ADMIN)
+                        .requestMatchers(HttpMethod.DELETE,
+                                "/notifications/{notificationId}")
+                        .hasAnyRole(USER, ADMIN, MODERATOR, UBS_EMPLOYEE)
                         .anyRequest().hasAnyRole(ADMIN))
                 .logout(logout -> logout.logoutUrl("/logout")
                         .logoutRequestMatcher(new AntPathRequestMatcher("/management/logout", "GET"))

--- a/core/src/main/java/greencity/controller/NotificationController.java
+++ b/core/src/main/java/greencity/controller/NotificationController.java
@@ -1,18 +1,18 @@
 package greencity.controller;
 
 import greencity.constant.HttpStatuses;
+import greencity.dto.notifications.CreateNotificationDto;
 import greencity.dto.notifications.NotificationDto;
 import greencity.service.NotificationService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -76,5 +76,17 @@ public class NotificationController {
     @GetMapping("/unread/amount/{userId}")
     public ResponseEntity<Long> getAmountOfUnreadNotificationsByUserId(@PathVariable Long userId) {
         return ResponseEntity.ok().body(notificationService.getAmountOfUnreadNotificationsByUserId(userId));
+    }
+
+    @Operation(summary = "Create notification.")
+    @ApiResponses(value = {@ApiResponse(responseCode = "201", description = HttpStatuses.CREATED),
+            @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST),
+            @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED),
+            @ApiResponse(responseCode = "403", description = HttpStatuses.FORBIDDEN),
+            @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND)
+    })
+    @PostMapping("/create")
+    public ResponseEntity<NotificationDto> createNotification(@RequestBody @Valid CreateNotificationDto createNotification) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(notificationService.save(createNotification));
     }
 }

--- a/core/src/main/java/greencity/controller/NotificationController.java
+++ b/core/src/main/java/greencity/controller/NotificationController.java
@@ -1,10 +1,13 @@
 package greencity.controller;
 
+import greencity.annotations.CurrentUser;
 import greencity.constant.HttpStatuses;
 import greencity.dto.notifications.CreateNotificationDto;
 import greencity.dto.notifications.NotificationDto;
+import greencity.dto.user.UserVO;
 import greencity.service.NotificationService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
@@ -122,5 +125,25 @@ public class NotificationController {
     @PatchMapping("/markAsRead/{notificationId}")
     public ResponseEntity<NotificationDto> markAsRead(@PathVariable Long notificationId) {
         return ResponseEntity.status(HttpStatus.OK).body(notificationService.markAsRead(notificationId));
+    }
+
+    /**
+     * Method that deletes notification by notificationId.
+     *
+     * @param notificationId id of notification
+     * @param userVO authenticated user
+     * @return request status code
+     */
+    @Operation(summary = "Delete notification by id.")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = HttpStatuses.OK),
+            @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED),
+            @ApiResponse(responseCode = "403", description = HttpStatuses.FORBIDDEN),
+            @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND)
+    })
+    @DeleteMapping("/{notificationId}")
+    public ResponseEntity<Void> deleteNotificationById(@PathVariable Long notificationId,
+                                                       @Parameter(hidden = true) @CurrentUser UserVO userVO) {
+        notificationService.deleteById(notificationId, userVO.getId());
+        return ResponseEntity.ok().build();
     }
 }

--- a/core/src/main/java/greencity/controller/NotificationController.java
+++ b/core/src/main/java/greencity/controller/NotificationController.java
@@ -1,0 +1,80 @@
+package greencity.controller;
+
+import greencity.constant.HttpStatuses;
+import greencity.dto.notifications.NotificationDto;
+import greencity.service.NotificationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Validated
+@RestController
+@RequestMapping("/notifications")
+@RequiredArgsConstructor
+public class NotificationController {
+    private final NotificationService notificationService;
+
+    @Operation(summary = "Get three last notifications for user.")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = HttpStatuses.OK),
+            @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED),
+            @ApiResponse(responseCode = "403", description = HttpStatuses.FORBIDDEN),
+            @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND)
+    })
+    @GetMapping("/newest/{userId}")
+    public ResponseEntity<List<NotificationDto>> getThreeLastNotificationsForUser(@PathVariable Long userId) {
+        return ResponseEntity.ok().body(notificationService.getThreeLastUnreadNotificationsForUser(userId));
+    }
+
+    @Operation(summary = "Get all notifications for user.")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = HttpStatuses.OK),
+            @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED),
+            @ApiResponse(responseCode = "403", description = HttpStatuses.FORBIDDEN),
+            @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND)
+    })
+    @GetMapping("/{userId}")
+    public ResponseEntity<List<NotificationDto>> getAllNotificationsForUser(@PathVariable Long userId) {
+        return ResponseEntity.ok().body(notificationService.findAllForUser(userId));
+    }
+
+    @Operation(summary = "Get all unread notifications for user.")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = HttpStatuses.OK),
+            @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED),
+            @ApiResponse(responseCode = "403", description = HttpStatuses.FORBIDDEN),
+            @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND)
+    })
+    @GetMapping("/unread/{userId}")
+    public ResponseEntity<List<NotificationDto>> getUnreadNotificationsForUser(@PathVariable Long userId) {
+        return ResponseEntity.ok().body(notificationService.getUnreadNotificationsForUser(userId));
+    }
+
+    @Operation(summary = "Get all unread notifications by section for user.")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = HttpStatuses.OK),
+            @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED),
+            @ApiResponse(responseCode = "403", description = HttpStatuses.FORBIDDEN),
+            @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND)
+    })
+    @GetMapping("/unread/{userId}/{section}")
+    public ResponseEntity<List<NotificationDto>> getUnreadNotificationsBySection(@PathVariable Long userId, @PathVariable String section) {
+        return ResponseEntity.ok().body(notificationService.getUnreadBySection(userId, section));
+    }
+
+    @Operation(summary = "Get amount of unread notifications for user.")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = HttpStatuses.OK),
+            @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED),
+            @ApiResponse(responseCode = "403", description = HttpStatuses.FORBIDDEN),
+            @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND)
+    })
+    @GetMapping("/unread/amount/{userId}")
+    public ResponseEntity<Long> getAmountOfUnreadNotificationsByUserId(@PathVariable Long userId) {
+        return ResponseEntity.ok().body(notificationService.getAmountOfUnreadNotificationsByUserId(userId));
+    }
+}

--- a/core/src/main/java/greencity/controller/NotificationController.java
+++ b/core/src/main/java/greencity/controller/NotificationController.java
@@ -23,6 +23,17 @@ import java.util.List;
 public class NotificationController {
     private final NotificationService notificationService;
 
+    @Operation(summary = "Read notification by id.")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = HttpStatuses.OK),
+            @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED),
+            @ApiResponse(responseCode = "403", description = HttpStatuses.FORBIDDEN),
+            @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND)
+    })
+    @GetMapping("/{notificationId}")
+    public ResponseEntity<NotificationDto> readNotificationById(@PathVariable Long notificationId) {
+        return ResponseEntity.ok().body(notificationService.findById(notificationId));
+    }
+
     @Operation(summary = "Get three last notifications for user.")
     @ApiResponses(value = {@ApiResponse(responseCode = "200", description = HttpStatuses.OK),
             @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED),
@@ -40,7 +51,7 @@ public class NotificationController {
             @ApiResponse(responseCode = "403", description = HttpStatuses.FORBIDDEN),
             @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND)
     })
-    @GetMapping("/{userId}")
+    @GetMapping("/user/{userId}")
     public ResponseEntity<List<NotificationDto>> getAllNotificationsForUser(@PathVariable Long userId) {
         return ResponseEntity.ok().body(notificationService.findAllForUser(userId));
     }
@@ -88,5 +99,28 @@ public class NotificationController {
     @PostMapping("/create")
     public ResponseEntity<NotificationDto> createNotification(@RequestBody @Valid CreateNotificationDto createNotification) {
         return ResponseEntity.status(HttpStatus.CREATED).body(notificationService.save(createNotification));
+    }
+
+    @Operation(summary = "Mark all notifications as read.")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = HttpStatuses.OK),
+            @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED),
+            @ApiResponse(responseCode = "403", description = HttpStatuses.FORBIDDEN),
+            @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND)
+    })
+    @PatchMapping("/markAllAsRead/{userId}")
+    public ResponseEntity<List<NotificationDto>> markAllAsRead(@PathVariable Long userId) {
+        return ResponseEntity.status(HttpStatus.OK).body(notificationService.markAllAsRead(userId));
+    }
+
+    @Operation(summary = "Mark notification as read.")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = HttpStatuses.OK),
+            @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST),
+            @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED),
+            @ApiResponse(responseCode = "403", description = HttpStatuses.FORBIDDEN),
+            @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND)
+    })
+    @PatchMapping("/markAsRead/{notificationId}")
+    public ResponseEntity<NotificationDto> markAsRead(@PathVariable Long notificationId) {
+        return ResponseEntity.status(HttpStatus.OK).body(notificationService.markAsRead(notificationId));
     }
 }

--- a/dao/src/main/java/greencity/entity/Notification.java
+++ b/dao/src/main/java/greencity/entity/Notification.java
@@ -1,0 +1,53 @@
+package greencity.entity;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "notifications")
+public class Notification {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sender_user_id")
+    private User senderUser;
+
+    @Size(max = 255)
+    @NotNull
+    @Column(name = "section", nullable = false)
+    private String section;
+
+    @Size(max = 255)
+    @Column(name = "title")
+    private String title;
+
+    @NotNull
+    @Column(name = "message", nullable = false, length = Integer.MAX_VALUE)
+    private String message;
+
+    @NotNull
+    @Column(name = "created_at", nullable = false)
+    @DateTimeFormat(pattern = "yyyy-MM-dd-HH-mm-ss.zzz")
+    private LocalDateTime createdAt;
+
+    @NotNull
+    @Column(name = "is_read", nullable = false)
+    private Boolean isRead = false;
+
+}

--- a/dao/src/main/java/greencity/entity/Notification.java
+++ b/dao/src/main/java/greencity/entity/Notification.java
@@ -3,14 +3,16 @@ package greencity.entity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDateTime;
 
 @Getter
 @Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 @Entity
 @Table(name = "notifications")
 public class Notification {

--- a/dao/src/main/java/greencity/enums/NotificationSections.java
+++ b/dao/src/main/java/greencity/enums/NotificationSections.java
@@ -1,0 +1,6 @@
+package greencity.enums;
+
+public enum NotificationSections {
+    GREENCITY,
+    PICKUP
+}

--- a/dao/src/main/java/greencity/repository/NotificationRepo.java
+++ b/dao/src/main/java/greencity/repository/NotificationRepo.java
@@ -1,0 +1,31 @@
+package greencity.repository;
+
+import greencity.entity.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface NotificationRepo extends JpaRepository<Notification, Long> {
+
+    Optional<Notification> findById(Long id);
+
+    @Query(nativeQuery = true, value = "SELECT * FROM notifications WHERE user_id = :userId AND is_read = false ORDER BY created_at DESC LIMIT 3")
+    List<Notification> getThreeLastUnreadNotificationsForUser(@Param("userId") Long id);
+
+    List<Notification> findAllByUser_IdOrderByCreatedAtDesc(Long id);
+    @Query(nativeQuery = true, value = "SELECT * FROM notifications WHERE user_id = :userId AND is_read = false ORDER BY created_at DESC")
+    List<Notification> findAllUnreadForUser(@Param("userId") Long id);
+
+    @Query(nativeQuery = true, value = "SELECT * FROM notifications WHERE user_id = :userId AND is_read = false AND section = :section ORDER BY created_at DESC")
+    List<Notification> findAllUnreadBySection(@Param("userId") Long id, @Param("section") String section);
+
+    Notification findByIdAndUser_Id(Long id, Long userId);
+
+    @Query(nativeQuery = true, value = "SELECT COUNT(*) FROM notifications WHERE user_id = :userId AND is_read = false")
+    Long getAmountOfUnreadNotificationsByUserId(@Param("userId") Long id);
+
+
+}

--- a/dao/src/main/java/greencity/repository/NotificationRepo.java
+++ b/dao/src/main/java/greencity/repository/NotificationRepo.java
@@ -27,5 +27,10 @@ public interface NotificationRepo extends JpaRepository<Notification, Long> {
     @Query(nativeQuery = true, value = "SELECT COUNT(*) FROM notifications WHERE user_id = :userId AND is_read = false")
     Long getAmountOfUnreadNotificationsByUserId(@Param("userId") Long id);
 
-
+    /***
+     * Method that allow you to delete notification by id.
+     *
+     * @param notificationId a value of {@link Long}
+     */
+    void deleteById(Long notificationId);
 }

--- a/dao/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/dao/src/main/resources/db/changelog/db.changelog-master.xml
@@ -176,5 +176,6 @@
     <include file="db/changelog/logs/ch-drop-places-table-Bokalo.xml"/>
     <include file="db/changelog/logs/ch-drop-news-subscribers-table-Bokalo.xml"/>
     <include file="db/changelog/logs/ch-drop-user-friends-table-Bokalo.xml"/>
+    <include file="db/changelog/logs/ch-add-table-notifications-Mozil.xml"/>
 </databaseChangeLog>
 

--- a/dao/src/main/resources/db/changelog/logs/ch-add-table-notifications-Mozil.xml
+++ b/dao/src/main/resources/db/changelog/logs/ch-add-table-notifications-Mozil.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="ushh789" author="Oleksandr Mozil">
+        <createTable tableName="notifications">
+            <column name="id" autoIncrement="true" type="BIGINT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="user_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="sender_user_id" type="BIGINT">
+                <constraints nullable="true"/>
+            </column>
+            <column name="section" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="title" type="VARCHAR(255)">
+                <constraints nullable="true"/>
+            </column>
+            <column name="message" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="created_at" type="TIMESTAMP" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+            <column name="is_read" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <addDefaultValue columnDataType="BOOLEAN" columnName="is_read" defaultValueBoolean="false"
+                         tableName="notifications" />
+
+        <addForeignKeyConstraint baseTableName="notifications"
+                                 baseColumnNames="user_id"
+                                 constraintName="fk_user"
+                                 referencedTableName="users"
+                                 referencedColumnNames="id"/>
+        <addForeignKeyConstraint baseTableName="notifications"
+                                 baseColumnNames="sender_user_id"
+                                 constraintName="fk_sender_user"
+                                 referencedTableName="users"
+                                 referencedColumnNames="id"/>
+    </changeSet>
+</databaseChangeLog>

--- a/service-api/src/main/java/greencity/dto/notifications/CreateNotificationDto.java
+++ b/service-api/src/main/java/greencity/dto/notifications/CreateNotificationDto.java
@@ -1,0 +1,23 @@
+package greencity.dto.notifications;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+import lombok.Value;
+
+import java.io.Serializable;
+
+@Value
+@Builder
+public class CreateNotificationDto implements Serializable {
+    Long userId;
+    Long senderId;
+    @NotNull
+    @Size(max = 255)
+    String section;
+    @NotNull
+    @Size(max = 255)
+    String title;
+    @NotNull
+    String message;
+}

--- a/service-api/src/main/java/greencity/dto/notifications/NotificationDto.java
+++ b/service-api/src/main/java/greencity/dto/notifications/NotificationDto.java
@@ -1,0 +1,36 @@
+package greencity.dto.notifications;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.*;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+@Builder
+public class NotificationDto implements Serializable {
+    @NotNull
+    @Min(1)
+    Long id;
+    @NotNull
+    NotificationUserDto user;
+    @NotNull
+    NotificationUserDto senderUser;
+    @NotNull
+    @Size(max = 255)
+    String section;
+    @NotNull
+    @Size(max = 255)
+    String title;
+    String message;
+    @NotNull
+    LocalDateTime createdAt;
+    @NotNull
+    Boolean isRead;
+}

--- a/service-api/src/main/java/greencity/dto/notifications/NotificationUserDto.java
+++ b/service-api/src/main/java/greencity/dto/notifications/NotificationUserDto.java
@@ -1,0 +1,21 @@
+package greencity.dto.notifications;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+import java.io.Serializable;
+
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@EqualsAndHashCode
+public class NotificationUserDto implements Serializable {
+    @NotNull
+    @Min(1)
+    Long id;
+    @NotNull
+    String name;
+}

--- a/service-api/src/main/java/greencity/service/NotificationService.java
+++ b/service-api/src/main/java/greencity/service/NotificationService.java
@@ -1,6 +1,6 @@
 package greencity.service;
 
-import greencity.dto.notifications.CreateNotification;
+import greencity.dto.notifications.CreateNotificationDto;
 import greencity.dto.notifications.NotificationDto;
 
 import java.util.List;
@@ -16,7 +16,7 @@ public interface NotificationService {
 
     Long getAmountOfUnreadNotificationsByUserId(Long userId);
 
-    NotificationDto save(CreateNotification createNotification);
+    NotificationDto save(CreateNotificationDto createNotification);
 
     NotificationDto findById(Long id);
 

--- a/service-api/src/main/java/greencity/service/NotificationService.java
+++ b/service-api/src/main/java/greencity/service/NotificationService.java
@@ -23,4 +23,6 @@ public interface NotificationService {
     List<NotificationDto> markAllAsRead(Long userId);
 
     NotificationDto markAsRead(Long notificationId);
+
+    void deleteById(Long notificationId, Long userId);
 }

--- a/service-api/src/main/java/greencity/service/NotificationService.java
+++ b/service-api/src/main/java/greencity/service/NotificationService.java
@@ -1,0 +1,26 @@
+package greencity.service;
+
+import greencity.dto.notifications.CreateNotification;
+import greencity.dto.notifications.NotificationDto;
+
+import java.util.List;
+
+public interface NotificationService {
+    List<NotificationDto> findAllForUser(Long userId);
+
+    List<NotificationDto> getUnreadNotificationsForUser(Long userId);
+
+    List<NotificationDto> getThreeLastUnreadNotificationsForUser(Long userId);
+
+    List<NotificationDto> getUnreadBySection(Long userId, String section);
+
+    Long getAmountOfUnreadNotificationsByUserId(Long userId);
+
+    NotificationDto save(CreateNotification createNotification);
+
+    NotificationDto findById(Long id);
+
+    void markAllAsRead(Long userId);
+
+    void markAsRead(Long notificationId);
+}

--- a/service-api/src/main/java/greencity/service/NotificationService.java
+++ b/service-api/src/main/java/greencity/service/NotificationService.java
@@ -20,7 +20,7 @@ public interface NotificationService {
 
     NotificationDto findById(Long id);
 
-    void markAllAsRead(Long userId);
+    List<NotificationDto> markAllAsRead(Long userId);
 
-    void markAsRead(Long notificationId);
+    NotificationDto markAsRead(Long notificationId);
 }

--- a/service/src/main/java/greencity/mapping/CreateNotificationDtoMapper.java
+++ b/service/src/main/java/greencity/mapping/CreateNotificationDtoMapper.java
@@ -1,0 +1,18 @@
+package greencity.mapping;
+
+import greencity.dto.notifications.CreateNotificationDto;
+import greencity.entity.Notification;
+import org.modelmapper.AbstractConverter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CreateNotificationDtoMapper extends AbstractConverter<CreateNotificationDto, Notification> {
+    @Override
+    public Notification convert(CreateNotificationDto createNotificationDto) {
+        return Notification.builder()
+            .title(createNotificationDto.getTitle())
+            .message(createNotificationDto.getMessage())
+            .section(createNotificationDto.getSection())
+            .build();
+    }
+}

--- a/service/src/main/java/greencity/mapping/NotificationDtoMapper.java
+++ b/service/src/main/java/greencity/mapping/NotificationDtoMapper.java
@@ -1,0 +1,32 @@
+package greencity.mapping;
+
+import greencity.dto.notifications.NotificationDto;
+import greencity.dto.notifications.NotificationUserDto;
+import greencity.entity.Notification;
+import greencity.entity.User;
+import org.modelmapper.AbstractConverter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class NotificationDtoMapper extends AbstractConverter<Notification, NotificationDto> {
+    @Override
+    public NotificationDto convert(Notification notification) {
+        return NotificationDto.builder()
+                .id(notification.getId())
+                .user(convertUser(notification.getUser()))
+                .senderUser(convertUser(notification.getSenderUser()))
+                .section(notification.getSection())
+                .title(notification.getTitle())
+                .message(notification.getMessage())
+                .createdAt(notification.getCreatedAt())
+                .isRead(notification.getIsRead())
+                .build();
+    }
+
+    private NotificationUserDto convertUser(User user) {
+        return NotificationUserDto.builder()
+                .id(user.getId())
+                .name(user.getName())
+                .build();
+    }
+}

--- a/service/src/main/java/greencity/service/NotificationServiceImpl.java
+++ b/service/src/main/java/greencity/service/NotificationServiceImpl.java
@@ -112,7 +112,7 @@ public class NotificationServiceImpl implements NotificationService {
     }
 
     @Override
-    public void markAllAsRead(Long userId) {
+    public List<NotificationDto> markAllAsRead(Long userId) {
         List<Notification> notifications = notificationRepo.findAllUnreadForUser(userId);
         if (notifications.isEmpty()) {
             throw new NotFoundException("User with id " + userId + " does not have any unread notifications");
@@ -121,19 +121,19 @@ public class NotificationServiceImpl implements NotificationService {
             notification.setIsRead(true);
             notificationRepo.save(notification);
         });
+        return notifications.stream()
+                .map(notificationMapper::convert)
+                .toList();
     }
 
-    @Override
-    public void markAsRead(Long notificationId) {
-        notificationRepo.findById(notificationId)
-                .ifPresentOrElse(
-                        notification -> {
-                            notification.setIsRead(true);
-                            notificationRepo.save(notification);
-                        },
-                        () -> {
-                            throw new NotFoundException("Notification with id " + notificationId + " not found");
-                        }
-                );
+        @Override
+    public NotificationDto markAsRead(Long notificationId) {
+        return notificationRepo.findById(notificationId)
+                .map(notification -> {
+                    notification.setIsRead(true);
+                    Notification savedNotification = notificationRepo.save(notification);
+                    return notificationMapper.convert(savedNotification);
+                })
+                .orElseThrow(() -> new NotFoundException("Notification with id " + notificationId + " not found"));
     }
 }

--- a/service/src/main/java/greencity/service/NotificationServiceImpl.java
+++ b/service/src/main/java/greencity/service/NotificationServiceImpl.java
@@ -8,6 +8,7 @@ import greencity.entity.User;
 import greencity.enums.NotificationSections;
 import greencity.exception.exceptions.BadRequestException;
 import greencity.exception.exceptions.NotFoundException;
+import greencity.exception.exceptions.UserHasNoPermissionToAccessException;
 import greencity.mapping.CreateNotificationDtoMapper;
 import greencity.mapping.NotificationDtoMapper;
 import greencity.repository.NotificationRepo;
@@ -126,7 +127,7 @@ public class NotificationServiceImpl implements NotificationService {
                 .toList();
     }
 
-        @Override
+    @Override
     public NotificationDto markAsRead(Long notificationId) {
         return notificationRepo.findById(notificationId)
                 .map(notification -> {
@@ -135,5 +136,19 @@ public class NotificationServiceImpl implements NotificationService {
                     return notificationMapper.convert(savedNotification);
                 })
                 .orElseThrow(() -> new NotFoundException("Notification with id " + notificationId + " not found"));
+    }
+
+    @Override
+    public void deleteById(Long notificationId, Long userId) {
+        if (!notificationRepo.existsById(notificationId)) {
+            throw new NotFoundException("Notification with id " + notificationId + " not found");
+        }
+
+        Notification notification = notificationRepo.findByIdAndUser_Id(notificationId, userId);
+        if (notification == null) {
+            throw new UserHasNoPermissionToAccessException("Notification with id " + notificationId + " does not belong to user with id " + userId);
+        }
+
+        notificationRepo.deleteById(notificationId);
     }
 }

--- a/service/src/main/java/greencity/service/NotificationServiceImpl.java
+++ b/service/src/main/java/greencity/service/NotificationServiceImpl.java
@@ -1,0 +1,119 @@
+package greencity.service;
+
+import greencity.constant.ErrorMessage;
+import greencity.dto.notifications.CreateNotification;
+import greencity.dto.notifications.NotificationDto;
+import greencity.entity.Notification;
+import greencity.enums.NotificationSections;
+import greencity.exception.exceptions.BadRequestException;
+import greencity.exception.exceptions.NotFoundException;
+import greencity.mapping.NotificationDtoMapper;
+import greencity.repository.NotificationRepo;
+import greencity.repository.UserRepo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationServiceImpl implements NotificationService {
+    private final NotificationRepo notificationRepo;
+    private final UserRepo userRepo;
+    private final NotificationDtoMapper notificationMapper;
+
+    @Override
+    public List<NotificationDto> findAllForUser(Long userId) {
+        if (!userRepo.existsById(userId)) {
+            throw new NotFoundException(ErrorMessage.USER_NOT_FOUND_BY_ID + userId);
+        }
+
+        return notificationRepo.findAllByUser_IdOrderByCreatedAtDesc(userId).stream()
+                .map(notificationMapper::convert)
+                .toList();
+    }
+
+    @Override
+    public List<NotificationDto> getUnreadNotificationsForUser(Long userId) {
+        if (!userRepo.existsById(userId)) {
+            throw new NotFoundException(ErrorMessage.USER_NOT_FOUND_BY_ID + userId);
+        }
+
+        return notificationRepo.findAllUnreadForUser(userId).stream()
+                .map(notificationMapper::convert)
+                .toList();
+    }
+
+    @Override
+    public List<NotificationDto> getThreeLastUnreadNotificationsForUser(Long userId) {
+        if (!userRepo.existsById(userId)) {
+            throw new NotFoundException(ErrorMessage.USER_NOT_FOUND_BY_ID + userId);
+        }
+
+        return notificationRepo.getThreeLastUnreadNotificationsForUser(userId).stream()
+                .map(notificationMapper::convert)
+                .toList();
+    }
+
+    @Override
+    public List<NotificationDto> getUnreadBySection(Long userId, String section) {
+        if (!userRepo.existsById(userId)) {
+            throw new NotFoundException(ErrorMessage.USER_NOT_FOUND_BY_ID + userId);
+        }
+        if (Arrays.stream(NotificationSections.values())
+                .noneMatch(notificationSections -> notificationSections.name().equalsIgnoreCase(section))) {
+            throw new BadRequestException("Section " + section + " does not exist");
+        }
+
+        return notificationRepo.findAllUnreadBySection(userId, section).stream()
+                .map(notificationMapper::convert)
+                .toList();
+    }
+
+    @Override
+    public Long getAmountOfUnreadNotificationsByUserId(Long userId) {
+        if (!userRepo.existsById(userId)) {
+            throw new NotFoundException(ErrorMessage.USER_NOT_FOUND_BY_ID + userId);
+        }
+        return notificationRepo.getAmountOfUnreadNotificationsByUserId(userId);
+    }
+
+    @Override
+    public NotificationDto save(CreateNotification createNotification) {
+        return null;
+    }
+
+    @Override
+    public NotificationDto findById(Long id) {
+        return notificationRepo.findById(id)
+                .map(notificationMapper::convert)
+                .orElseThrow(() -> new NotFoundException("Notification with id " + id + " not found"));
+    }
+
+    @Override
+    public void markAllAsRead(Long userId) {
+        List<Notification> notifications = notificationRepo.findAllUnreadForUser(userId);
+        if (notifications.isEmpty()) {
+            throw new NotFoundException("User with id " + userId + " does not have any unread notifications");
+        }
+        notifications.forEach(notification -> {
+            notification.setIsRead(true);
+            notificationRepo.save(notification);
+        });
+    }
+
+    @Override
+    public void markAsRead(Long notificationId) {
+        notificationRepo.findById(notificationId)
+                .ifPresentOrElse(
+                        notification -> {
+                            notification.setIsRead(true);
+                            notificationRepo.save(notification);
+                        },
+                        () -> {
+                            throw new NotFoundException("Notification with id " + notificationId + " not found");
+                        }
+                );
+    }
+}

--- a/service/src/test/java/greencity/service/NotificationServiceImplTest.java
+++ b/service/src/test/java/greencity/service/NotificationServiceImplTest.java
@@ -1,0 +1,57 @@
+package greencity.service;
+
+import greencity.entity.Notification;
+import greencity.exception.exceptions.NotFoundException;
+import greencity.exception.exceptions.UserHasNoPermissionToAccessException;
+import greencity.repository.NotificationRepo;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(SpringExtension.class)
+class NotificationServiceImplTest {
+    @Mock
+    private NotificationRepo notificationRepo;
+
+    @InjectMocks
+    private NotificationServiceImpl notificationService;
+
+    @Test
+    @DisplayName("Test deleteById method with correct notificationId and userId")
+    void deleteById_ValidData_NoExceptionThrown() {
+        Notification notification = new Notification();
+        when(notificationRepo.existsById(1L)).thenReturn(true);
+        when(notificationRepo.findByIdAndUser_Id(1L, 1L)).thenReturn(notification);
+        when(notificationRepo.findById(1L)).thenReturn(java.util.Optional.of(notification));
+
+        notificationService.deleteById(1L, 1L);
+
+        verify(notificationRepo, times(1)).deleteById(1L);
+    }
+
+    @Test
+    @DisplayName("Test deleteById method with incorrect notificationId")
+    void deleteById_IncorrectNotificationId_ExceptionThrown() {
+        when(notificationRepo.existsById(1L)).thenReturn(false);
+
+        assertThrows(NotFoundException.class, () -> notificationService.deleteById(1L, 1L));
+    }
+
+    @Test
+    @DisplayName("Test deleteById method when user has no permission to access delete notification")
+    void deleteById_IncorrectUserId_ExceptionThrown() {
+        Notification notification = new Notification();
+        when(notificationRepo.existsById(1L)).thenReturn(true);
+        when(notificationRepo.findByIdAndUser_Id(1L, 1L)).thenReturn(null);
+        when(notificationRepo.findById(1L)).thenReturn(java.util.Optional.of(notification));
+
+        assertThrows(UserHasNoPermissionToAccessException.class, () -> notificationService.deleteById(1L, 1L));
+    }
+}


### PR DESCRIPTION
# Pull request related to issue #327 and #324
## Changes:
1. Updated **SecurityConfig** to allow access for authenticated users with role **USER, ADMIN, MODERATOR, UBS_EMPLOYEE** to retrieve information about user's friends.

    >	**Secured endpoints:**
    >	- /notifications/{notificationId}
2.  Implemented additional methods in **NotificationController** to handle requests related to user's friends.
3. Added additional method with **Sprint JPA** in **NotificationRepo** to delete record from database.
4. Added additional method to **NotificationService** for deleting notification.
5. Implemented **NotificationServiceImpl** method to process deleting notification record from database.
## Usage:
1. Login as **USER** or any other role.
2. To delete notification on All notifications page you */notifications/{notificationsId}* endpoint. **USER** can delete only his own notification if it exists.
