### PR TITLE
[336] Event was canceled notification

### DIFF
--- a/core/src/main/java/greencity/config/SecurityConfig.java
+++ b/core/src/main/java/greencity/config/SecurityConfig.java
@@ -257,6 +257,7 @@ public class SecurityConfig {
                                 ECONEWS_COMMENTS,
                                 "/events/comments/{eventCommentId}",
                                 "/event/attenders/{eventId}",
+                                "/event/{eventId}",
                                 "/econews/{econewsId}",
                                 CUSTOM_SHOPPING_LIST_ITEMS,
                                 CUSTOM_SHOPPING_LIST_URL,

--- a/core/src/main/java/greencity/config/SecurityConfig.java
+++ b/core/src/main/java/greencity/config/SecurityConfig.java
@@ -163,6 +163,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET,
                                 "/event",
                                 "/event/{id}",
+                                "/event/attenders/{eventId}",
                                 "/achievements",
                                 CUSTOM_SHOPPING_LIST_ITEMS,
                                 CUSTOM_SHOPPING_LIST,
@@ -223,8 +224,8 @@ public class SecurityConfig {
                                 "/user/{userId}/habit",
                                 "/habit/custom",
                                 "/custom/shopping-list-items/{userId}/{habitId}/custom-shopping-list-items",
-                                "/event/get/{id}",
-                                "/event/create",
+                                "/event",
+                                "/event/attenders/{eventId}",
                                 "/notifications/**")
                         .hasAnyRole(USER, ADMIN, MODERATOR, UBS_EMPLOYEE)
                         .requestMatchers(HttpMethod.PUT,
@@ -255,6 +256,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.DELETE,
                                 ECONEWS_COMMENTS,
                                 "/events/comments/{eventCommentId}",
+                                "/event/attenders/{eventId}",
                                 "/econews/{econewsId}",
                                 CUSTOM_SHOPPING_LIST_ITEMS,
                                 CUSTOM_SHOPPING_LIST_URL,

--- a/core/src/main/java/greencity/controller/EventController.java
+++ b/core/src/main/java/greencity/controller/EventController.java
@@ -170,4 +170,21 @@ public class EventController {
                                                                        @Parameter(hidden = true) @CurrentUser UserVO user){
         return ResponseEntity.status(HttpStatus.OK).body(eventService.getAllEventAttenders(eventId, user));
     }
+
+    /**
+     * Method for deleting event by id.
+     *
+     * @param eventId id of event
+     * @param user {@link UserVO} of authenticated user
+     */
+    @Operation(summary = "Delete event by id")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
+            @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED),
+            @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND)
+    })
+    @DeleteMapping("/{eventId}")
+    public void deleteEvent(@PathVariable Long eventId, @Parameter(hidden = true) @CurrentUser UserVO user){
+        eventService.delete(eventId, user);
+    }
 }

--- a/core/src/main/java/greencity/controller/EventController.java
+++ b/core/src/main/java/greencity/controller/EventController.java
@@ -3,6 +3,7 @@ package greencity.controller;
 import greencity.annotations.MultipartValidation;
 import greencity.constant.HttpStatuses;
 import greencity.annotations.CurrentUser;
+import greencity.dto.event.EventAttenderDto;
 import greencity.dto.event.EventCreateDtoRequest;
 import greencity.dto.event.EventCreateDtoResponse;
 import greencity.dto.event.EventUpdateDtoRequest;
@@ -117,5 +118,56 @@ public class EventController {
             @Parameter(hidden = true) @CurrentUser UserVO user
     ){
         return ResponseEntity.status(HttpStatus.OK).body(eventService.update(eventUpdate, images, user));
+    }
+
+    /**
+     * Method for adding an attender to the event.
+     *
+     * @author Maksym Petukhov.
+     */
+    @Operation(summary = "Add an attender to the event")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
+            @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED),
+            @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND)
+    })
+    @PostMapping("/attenders/{eventId}")
+    public void addAttender(@PathVariable Long eventId, @Parameter(hidden = true) @CurrentUser UserVO user) {
+        eventService.addAttender(eventId, user);
+    }
+
+    /**
+     * Method for deleting an attender from the event.
+     *
+     * @param eventId id of event
+     * @param user    {@link UserVO} of authenticated user
+     */
+    @Operation(summary = "Delete an attender from the event")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
+            @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED),
+            @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND)
+    })
+    @DeleteMapping("/attenders/{eventId}")
+    public void deleteAttender(@PathVariable Long eventId, @Parameter(hidden = true) @CurrentUser UserVO user) {
+        eventService.deleteAttender(eventId, user);
+    }
+
+    /**
+     * Method for getting all event attenders by event id.
+     *
+     * @param eventId id of event
+     * @return list of {@link UserVO}
+     */
+    @Operation(summary = "Get all event attenders by event id")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
+            @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED),
+            @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND)
+    })
+    @GetMapping("/attenders/{eventId}")
+    public ResponseEntity<List<EventAttenderDto>> getAllEventAttenders(@PathVariable Long eventId,
+                                                                       @Parameter(hidden = true) @CurrentUser UserVO user){
+        return ResponseEntity.status(HttpStatus.OK).body(eventService.getAllEventAttenders(eventId, user));
     }
 }

--- a/dao/src/main/java/greencity/entity/Event.java
+++ b/dao/src/main/java/greencity/entity/Event.java
@@ -8,7 +8,9 @@ import org.hibernate.annotations.SourceType;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 @Entity
 @NoArgsConstructor
@@ -53,6 +55,12 @@ public class Event {
     @Column(name = "additional_images_id")
     @OneToMany(mappedBy = "event", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<AdditionalImage> additionalImages = new ArrayList<>();
+
+    @ManyToMany(fetch = FetchType.LAZY)
+    @JoinTable(name = "events_attenders",
+            joinColumns = @JoinColumn(name = "event_id"),
+            inverseJoinColumns = @JoinColumn(name = "user_id"))
+    private Set<User> attenders = new HashSet<>();
 
     public void setDates(@Size(min = 1, max = 7, message = "Must add from 1 to 7 sets of date, time and location parameters") List<EventDateLocation> dates) {
         if (this.dates != null) {

--- a/dao/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/dao/src/main/resources/db/changelog/db.changelog-master.xml
@@ -180,5 +180,6 @@
     <include file="db/changelog/logs/ch-add-user-friends-table-Petukhov.xml"/>
     <include file="db/changelog/logs/ch-add-table-notifications-Mozil.xml"/>
     <include file="db/changelog/logs/ch-crate-event-Mashkin-Andriy.xml"/>
+    <include file="db/changelog/logs/ch-add-table-events-attenders-Petukhov.xml"/>
 </databaseChangeLog>
 

--- a/dao/src/main/resources/db/changelog/logs/ch-add-table-events-attenders-Petukhov.xml
+++ b/dao/src/main/resources/db/changelog/logs/ch-add-table-events-attenders-Petukhov.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="Petukhov-2" author="Maksym Petukhov">
+        <createTable tableName="events_attenders">
+            <column name="event_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="user_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <addForeignKeyConstraint baseTableName="events_attenders"
+                                 baseColumnNames="event_id"
+                                 referencedTableName="events"
+                                 referencedColumnNames="id"
+                                 constraintName="fk_events_attenders_event"/>
+
+        <addForeignKeyConstraint baseTableName="events_attenders"
+                                 baseColumnNames="user_id"
+                                 referencedTableName="users"
+                                 referencedColumnNames="id"
+                                 constraintName="fk_events_attenders_user"/>
+
+        <rollback>
+            <dropTable tableName="events_attenders"/>
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/service-api/src/main/java/greencity/constant/ErrorMessage.java
+++ b/service-api/src/main/java/greencity/constant/ErrorMessage.java
@@ -135,6 +135,8 @@ public final class ErrorMessage {
     public static final String INVALID_DURATION = "The duration for such habit is lower than previously set";
     public static final String EVENT_NOT_FOUND_BY_ID = "Event doesn't exist by this id: ";
     public static final String EVENTS_NOT_SAVED = "Events are not saved";
+    public static final String USER_ALREADY_ATTENDS_EVENT = "User already attends this event";
+    public static final String USER_NOT_ATTENDS_EVENT = "User doesn't attend this event";
 
 
     private ErrorMessage() {

--- a/service-api/src/main/java/greencity/dto/event/EventAttenderDto.java
+++ b/service-api/src/main/java/greencity/dto/event/EventAttenderDto.java
@@ -1,0 +1,13 @@
+package greencity.dto.event;
+
+import lombok.*;
+
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@EqualsAndHashCode
+public class EventAttenderDto {
+    private Long id;
+    private String name;
+}

--- a/service-api/src/main/java/greencity/service/EventService.java
+++ b/service-api/src/main/java/greencity/service/EventService.java
@@ -3,10 +3,10 @@ package greencity.service;
 import greencity.dto.event.EventCreateDtoResponse;
 import greencity.dto.event.EventCreateDtoRequest;
 import greencity.dto.event.EventUpdateDtoRequest;
+import greencity.dto.event.EventAttenderDto;
 import greencity.dto.user.UserVO;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.sql.SQLException;
 import java.util.List;
 
 public interface EventService {
@@ -20,4 +20,28 @@ public interface EventService {
     EventCreateDtoResponse findEventById(Long id);
 
     EventCreateDtoResponse update(EventUpdateDtoRequest eventUpdate, MultipartFile[] images, UserVO user);
+
+    /**
+     * Method for adding attender to event.
+     *
+     * @param eventId id of event
+     * @param user {@link UserVO} of authenticated user
+     */
+    void addAttender(Long eventId, UserVO user);
+
+    /**
+     * Method for deleting attender from event.
+     *
+     * @param eventId id of event
+     * @param user {@link UserVO} of authenticated user
+     */
+    void deleteAttender(Long eventId, UserVO user);
+
+    /**
+     * Method for getting all event attenders by event id.
+     *
+     * @param eventId id of event
+     * @return list of {@link UserVO}
+     */
+    List<EventAttenderDto> getAllEventAttenders(Long eventId, UserVO user);
 }

--- a/service-api/src/main/java/greencity/service/EventService.java
+++ b/service-api/src/main/java/greencity/service/EventService.java
@@ -22,6 +22,14 @@ public interface EventService {
     EventCreateDtoResponse update(EventUpdateDtoRequest eventUpdate, MultipartFile[] images, UserVO user);
 
     /**
+     * Method for deleting event by id.
+     *
+     * @param id id of event
+     * @param user {@link UserVO} of authenticated user
+     */
+    void delete(Long id, UserVO user);
+
+    /**
      * Method for adding attender to event.
      *
      * @param eventId id of event

--- a/service/src/main/java/greencity/mapping/EventAttenderMapper.java
+++ b/service/src/main/java/greencity/mapping/EventAttenderMapper.java
@@ -1,0 +1,17 @@
+package greencity.mapping;
+
+import greencity.dto.event.EventAttenderDto;
+import greencity.entity.User;
+import org.modelmapper.AbstractConverter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class EventAttenderMapper extends AbstractConverter<User, EventAttenderDto> {
+    @Override
+    protected EventAttenderDto convert(User user) {
+        return EventAttenderDto.builder()
+                .id(user.getId())
+                .name(user.getFirstName())
+                .build();
+    }
+}


### PR DESCRIPTION

# Pull request related to issue #336
> **Note:** This pull request have to be merged after PR [[182](https://github.com/GreenCityProject/GreenCityMVP21_team1_May/pull/72)]

## Changes:
1. Added additional endpoint in **EventController** to handle requests related to event cancelation.
2. Added additional method in **EventService** to delete(cancel) event.
3. Implemented **EventServiceImpl** method to process deleting event.
4. Updated **SecurityConfig** to allow access for authenticated users with role **USER, ADMIN, MODERATOR, UBS_EMPLOYEE** to perform event delete actions.
   > **Secured endpoints:**
   >    - /event/{eventId} [DELETE]
5. Added logic to *delete* method in **EventServiceImpl** to send popup notification for event attenders about event cancellation.

## Usage: 
1. Login as **USER** or any other role.
2. To delete event perform [DELETE] request to the */event/{eventId}* endpoint. This action will delete specified event. After this action all information related to the event in database will be deleted (attenders, locations, images, etc.)
	> **Note:** Only **USER** with *Organizer* status or **ADMIN** role can perform this action.
3. After deleting event appropriate notification will be sent to all event attenders. 
    > **Message format:** *Unfortunately, event [Event name] was cancelled. [Date and Time]*